### PR TITLE
ci(dependabot): only check for updates once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: wednesday
+      time: "10:00"
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: wednesday
+      time: "10:00"


### PR DESCRIPTION
These updates get a little noisy and we don't need to update this right away. Set to every Wednesday morning since that day is usually pretty quiet